### PR TITLE
Change descriptions to description

### DIFF
--- a/SemanticMetaTags.php
+++ b/SemanticMetaTags.php
@@ -43,7 +43,7 @@ call_user_func( function () {
 
 	$GLOBALS['egSMTMetaTagsContentPropertySelector'] = array(
 		'keywords' => '',
-		'descriptions' => '',
+		'description' => '',
 		'author' => ''
 	);
 

--- a/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
+++ b/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
@@ -29,7 +29,7 @@ class MetaTagsContentGenerationIntegrationTest extends MwDBaseUnitTestCase {
 
 		$metaTagsContentPropertySelector = array(
 			'keywords' => 'SMT keywords',
-			'descriptions' => '',
+			'description' => '',
 			'og:title' => 'SMT title'
 		);
 


### PR DESCRIPTION
The correct  name of this tag is [description](http://www.metatags.info/meta_name_description). Have not fiddled with the README since there is another pull request on that file from Jeroen.