### PR TITLE
Adds TagsBlacklist and FallbackUseForMultipleProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,20 @@ The recommended way to install Semantic Meta Tags is by using [Composer][compose
 
 ## Usage
 
-You can specify which meta tags you want to enable, and where their values should come from with the `egSMTMetaTagsContentPropertySelector` setting.
+You can specify which meta tags you want to enable, and where their values should come from with the `smtgTagsContentPropertySelector` setting.
 
-The setting is an array that has the meta tags as keys (the left part). The values (right part) contain the name of the semantic property on your wiki that you want to use the value of. In case you want to put multiple property values in your meta tag, you can enter multiple property names, separated by commas. If a given property has multiple values on your wiki page, the values concatenated into a single, separated by commas.
+The setting is an array that has the meta tags as keys (the left part). The values (right part) contain the name of the semantic property on your wiki that you want to use the value of. In case you want to put multiple property values in your meta tag, you can enter multiple property names, separated by commas.
+
+If `smtgFallbackUseForMultipleProperties` is set `true` then the first property that returns a valid content for an assigned tag will be used exclusively. If a given property has multiple values (including subobjects) on your wiki page, the values are concatenated into a single string separated by commas.
+
+The setting `smtgTagsStaticContentDescriptor` can be used to describe static content to a selected `<meta>` tag while tags specified in `smtgTagsBlacklist` are generally disabled for free assignments.
 
 If a tag contains a `og:` it is identified as an [Open Graph][opg] metadata tag and annotated using `meta property=""` description.
-
-The setting `egSMTMetaTagsStaticContentDescriptor` can be used to describe the static content of a selected `<meta>` tag.
 
 Example:
 
 ```php
-$GLOBALS['egSMTMetaTagsContentPropertySelector'] = array(
+$GLOBALS['smtgTagsContentPropertySelector'] = array(
 
 	// Standard meta tags
 	'keywords' => 'Has keywords, Has another keyword',
@@ -64,10 +66,17 @@ $GLOBALS['egSMTMetaTagsContentPropertySelector'] = array(
 	'og:title' => 'Has title'
 );
 
-$GLOBALS['egSMTMetaTagsStaticContentDescriptor'] = array(
+$GLOBALS['smtgTagsStaticContentDescriptor'] = array(
 
 	// Static content tag
 	'some:tag' => 'Content that is static'
+);
+
+$GLOBALS['smtgTagsBlacklist'] = array(
+
+	// Disabled for free assignments
+	'generator',
+	'robots'
 );
 ```
 

--- a/SemanticMetaTags.php
+++ b/SemanticMetaTags.php
@@ -46,10 +46,12 @@ call_user_func( function () {
 	$GLOBALS['egSMTMetaTagsStaticContentDescriptor'] = array();
 
 	// Tags generally assumed to be reserved or excluded for free use
-	$GLOBALS['egSemanticMetaTagsBlackList'] = array(
+	$GLOBALS['egSemanticMetaTagsBlacklist'] = array(
 		'generator',
 		'robots'
 	);
+
+	$GLOBALS['egSemanticMetaTagsMultiplePropertiesToUseForFallback'] = false;
 
 	// Finalize extension setup
 	$GLOBALS['wgExtensionFunctions'][] = function() {
@@ -57,7 +59,8 @@ call_user_func( function () {
 		$configuration = array(
 			'metaTagsContentPropertySelector' => $GLOBALS['egSMTMetaTagsContentPropertySelector'],
 			'metaTagsStaticContentDescriptor' => $GLOBALS['egSMTMetaTagsStaticContentDescriptor'],
-			'metaTagsBlacklist' => $GLOBALS['egSemanticMetaTagsBlackList']
+			'metaTagsBlacklist' => $GLOBALS['egSemanticMetaTagsBlacklist'],
+			'metaTagsMultiplePropertiesToUseForFallback' => $GLOBALS['egSemanticMetaTagsMultiplePropertiesToUseForFallback']
 		);
 
 		$hookRegistry = new HookRegistry( $configuration );

--- a/SemanticMetaTags.php
+++ b/SemanticMetaTags.php
@@ -42,25 +42,25 @@ call_user_func( function () {
 	$GLOBALS['wgMessagesDirs']['semantic-meta-tags'] = __DIR__ . '/i18n';
 
 	// Default settings
-	$GLOBALS['egSMTMetaTagsContentPropertySelector'] = array();
-	$GLOBALS['egSMTMetaTagsStaticContentDescriptor'] = array();
+	$GLOBALS['smtgTagsContentPropertySelector'] = array();
+	$GLOBALS['smtgTagsStaticContentDescriptor'] = array();
 
 	// Tags generally assumed to be reserved or excluded for free use
-	$GLOBALS['egSemanticMetaTagsBlacklist'] = array(
+	$GLOBALS['smtgTagsBlacklist'] = array(
 		'generator',
 		'robots'
 	);
 
-	$GLOBALS['egSemanticMetaTagsMultiplePropertiesToUseForFallback'] = false;
+	$GLOBALS['smtgFallbackUseForMultipleProperties'] = false;
 
 	// Finalize extension setup
 	$GLOBALS['wgExtensionFunctions'][] = function() {
 
 		$configuration = array(
-			'metaTagsContentPropertySelector' => $GLOBALS['egSMTMetaTagsContentPropertySelector'],
-			'metaTagsStaticContentDescriptor' => $GLOBALS['egSMTMetaTagsStaticContentDescriptor'],
-			'metaTagsBlacklist' => $GLOBALS['egSemanticMetaTagsBlacklist'],
-			'metaTagsMultiplePropertiesToUseForFallback' => $GLOBALS['egSemanticMetaTagsMultiplePropertiesToUseForFallback']
+			'metaTagsContentPropertySelector' => $GLOBALS['smtgTagsContentPropertySelector'],
+			'metaTagsStaticContentDescriptor' => $GLOBALS['smtgTagsStaticContentDescriptor'],
+			'metaTagsBlacklist' => $GLOBALS['smtgTagsBlacklist'],
+			'metaTagsFallbackUseForMultipleProperties' => $GLOBALS['smtgFallbackUseForMultipleProperties']
 		);
 
 		$hookRegistry = new HookRegistry( $configuration );

--- a/SemanticMetaTags.php
+++ b/SemanticMetaTags.php
@@ -45,12 +45,19 @@ call_user_func( function () {
 	$GLOBALS['egSMTMetaTagsContentPropertySelector'] = array();
 	$GLOBALS['egSMTMetaTagsStaticContentDescriptor'] = array();
 
+	// Tags generally assumed to be reserved or excluded for free use
+	$GLOBALS['egSemanticMetaTagsBlackList'] = array(
+		'generator',
+		'robots'
+	);
+
 	// Finalize extension setup
 	$GLOBALS['wgExtensionFunctions'][] = function() {
 
 		$configuration = array(
 			'metaTagsContentPropertySelector' => $GLOBALS['egSMTMetaTagsContentPropertySelector'],
-			'metaTagsStaticContentDescriptor' => $GLOBALS['egSMTMetaTagsStaticContentDescriptor']
+			'metaTagsStaticContentDescriptor' => $GLOBALS['egSMTMetaTagsStaticContentDescriptor'],
+			'metaTagsBlacklist' => $GLOBALS['egSemanticMetaTagsBlackList']
 		);
 
 		$hookRegistry = new HookRegistry( $configuration );

--- a/src/FallbackSemanticDataFetcher.php
+++ b/src/FallbackSemanticDataFetcher.php
@@ -8,7 +8,7 @@ use SMW\ParserData;
 
 /**
  * Sometimes the ParserCache provides an outdated ParserOutput with no
- * external data (e.g SematicData) attached therefore try the get the data
+ * external data (e.g SematicData) attached therefore try to get the data
  * by other means.
  *
  * @license GNU GPL v2+
@@ -16,7 +16,7 @@ use SMW\ParserData;
  *
  * @author mwjames
  */
-class LazySemanticDataFetcher {
+class FallbackSemanticDataFetcher {
 
 	/**
 	 * @var ParserData

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -49,13 +49,13 @@ class HookRegistry {
 				$parserOutput
 			);
 
-			$lazySemanticDataFetcher = new LazySemanticDataFetcher(
+			$fallbackSemanticDataFetcher = new FallbackSemanticDataFetcher(
 				$parserData,
 				ApplicationFactory::getInstance()->getStore()
 			);
 
 			$metaTagsModifier = new MetaTagsModifier(
-				new PropertyValueContentFinder( $lazySemanticDataFetcher ),
+				new PropertyValueContentFinder( $fallbackSemanticDataFetcher ),
 				new OutputPageTagFormatter( $outputPage )
 			);
 

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -58,7 +58,7 @@ class HookRegistry {
 			$outputPageTagFormatter->setMetaTagsBlacklist( $configuration['metaTagsBlacklist'] );
 
 			$propertyValueContentFinder = new PropertyValueContentFinder( $fallbackSemanticDataFetcher );
-			$propertyValueContentFinder->setMultiplePropertiesToUseForFallback( $configuration['metaTagsMultiplePropertiesToUseForFallback']  );
+			$propertyValueContentFinder->useFallbackChainForMultipleProperties( $configuration['metaTagsFallbackUseForMultipleProperties'] );
 
 			$metaTagsModifier = new MetaTagsModifier(
 				$propertyValueContentFinder,

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -57,8 +57,11 @@ class HookRegistry {
 			$outputPageTagFormatter = new OutputPageTagFormatter( $outputPage );
 			$outputPageTagFormatter->setMetaTagsBlacklist( $configuration['metaTagsBlacklist'] );
 
+			$propertyValueContentFinder = new PropertyValueContentFinder( $fallbackSemanticDataFetcher );
+			$propertyValueContentFinder->setMultiplePropertiesToUseForFallback( $configuration['metaTagsMultiplePropertiesToUseForFallback']  );
+
 			$metaTagsModifier = new MetaTagsModifier(
-				new PropertyValueContentFinder( $fallbackSemanticDataFetcher ),
+				$propertyValueContentFinder,
 				$outputPageTagFormatter
 			);
 

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -54,9 +54,12 @@ class HookRegistry {
 				ApplicationFactory::getInstance()->getStore()
 			);
 
+			$outputPageTagFormatter = new OutputPageTagFormatter( $outputPage );
+			$outputPageTagFormatter->setMetaTagsBlacklist( $configuration['metaTagsBlacklist'] );
+
 			$metaTagsModifier = new MetaTagsModifier(
 				new PropertyValueContentFinder( $fallbackSemanticDataFetcher ),
-				new OutputPageTagFormatter( $outputPage )
+				$outputPageTagFormatter
 			);
 
 			$metaTagsModifier->setMetaTagsContentPropertySelector( $configuration['metaTagsContentPropertySelector'] );

--- a/src/OutputPageTagFormatter.php
+++ b/src/OutputPageTagFormatter.php
@@ -18,6 +18,11 @@ class OutputPageTagFormatter {
 	private $outputPage;
 
 	/**
+	 * @var array
+	 */
+	private $metaTagsBlacklist = array();
+
+	/**
 	 * @var boolean
 	 */
 	private $usedOpenGraphProtocolMarkup = false;
@@ -29,6 +34,15 @@ class OutputPageTagFormatter {
 	 */
 	public function __construct( OutputPage $outputPage ) {
 		$this->outputPage = $outputPage;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param array $metaTagsBlacklist
+	 */
+	public function setMetaTagsBlacklist( array $metaTagsBlacklist ) {
+		$this->metaTagsBlacklist = array_flip( $metaTagsBlacklist );
 	}
 
 	/**
@@ -55,6 +69,10 @@ class OutputPageTagFormatter {
 
 		$tag = strtolower( htmlspecialchars( trim( $tag ) ) );
 		$content = htmlspecialchars( $content );
+
+		if ( isset( $this->metaTagsBlacklist[ $tag ] ) ) {
+			return;
+		}
 
 		// If a tag contains a `og:` such as `og:title` it is expected to be a
 		// OpenGraph protocol tag

--- a/src/PropertyValueContentFinder.php
+++ b/src/PropertyValueContentFinder.php
@@ -21,12 +21,30 @@ class PropertyValueContentFinder {
 	private $fallbackSemanticDataFetcher;
 
 	/**
+	 * Whether multiple properties should be used as fallback chain where the
+	 * first available property with content will determine the end of the
+	 * processing or content being simply concatenated
+	 *
+	 * @var boolean
+	 */
+	private $multiplePropertiesToUseForFallback = false;
+
+	/**
 	 * @since 1.0
 	 *
 	 * @param FallbackSemanticDataFetcher $fallbackSemanticDataFetcher
 	 */
 	public function __construct( FallbackSemanticDataFetcher $fallbackSemanticDataFetcher ) {
 		$this->fallbackSemanticDataFetcher = $fallbackSemanticDataFetcher;
+	}
+
+	/**
+	 * @since  1.0
+	 *
+	 * @param boolean multiplePropertiesToUseForFallback
+	 */
+	public function setMultiplePropertiesToUseForFallback( $multiplePropertiesToUseForFallback ) {
+		$this->multiplePropertiesToUseForFallback = $multiplePropertiesToUseForFallback;
 	}
 
 	/**
@@ -41,6 +59,13 @@ class PropertyValueContentFinder {
 		$values = array();
 
 		foreach ( $propertyNames as $property ) {
+
+			// If content is already present and the fallback is ought to be
+			// used stop requesting additional content
+			if ( $this->multiplePropertiesToUseForFallback && $values !== array() ) {
+				break;
+			}
+
 			$this->findContentForProperty( trim( $property ), $values );
 		}
 

--- a/src/PropertyValueContentFinder.php
+++ b/src/PropertyValueContentFinder.php
@@ -21,13 +21,13 @@ class PropertyValueContentFinder {
 	private $fallbackSemanticDataFetcher;
 
 	/**
-	 * Whether multiple properties should be used as fallback chain where the
-	 * first available property with content will determine the end of the
+	 * Whether multiple properties should be used through a fallback chain where
+	 * the first available property with content will determine the end of the
 	 * processing or content being simply concatenated
 	 *
 	 * @var boolean
 	 */
-	private $multiplePropertiesToUseForFallback = false;
+	private $useFallbackChainForMultipleProperties = false;
 
 	/**
 	 * @since 1.0
@@ -41,10 +41,10 @@ class PropertyValueContentFinder {
 	/**
 	 * @since  1.0
 	 *
-	 * @param boolean multiplePropertiesToUseForFallback
+	 * @param boolean useFallbackChainForMultipleProperties
 	 */
-	public function setMultiplePropertiesToUseForFallback( $multiplePropertiesToUseForFallback ) {
-		$this->multiplePropertiesToUseForFallback = $multiplePropertiesToUseForFallback;
+	public function useFallbackChainForMultipleProperties( $useFallbackChainForMultipleProperties ) {
+		$this->useFallbackChainForMultipleProperties = $useFallbackChainForMultipleProperties;
 	}
 
 	/**
@@ -62,7 +62,7 @@ class PropertyValueContentFinder {
 
 			// If content is already present and the fallback is ought to be
 			// used stop requesting additional content
-			if ( $this->multiplePropertiesToUseForFallback && $values !== array() ) {
+			if ( $this->useFallbackChainForMultipleProperties && $values !== array() ) {
 				break;
 			}
 

--- a/src/PropertyValueContentFinder.php
+++ b/src/PropertyValueContentFinder.php
@@ -16,17 +16,17 @@ use SMWDIUri as DIUri;
 class PropertyValueContentFinder {
 
 	/**
-	 * @var LazySemanticDataFetcher
+	 * @var FallbackSemanticDataFetcher
 	 */
-	private $lazySemanticDataFetcher;
+	private $fallbackSemanticDataFetcher;
 
 	/**
 	 * @since 1.0
 	 *
-	 * @param LazySemanticDataFetcher $lazySemanticDataFetcher
+	 * @param FallbackSemanticDataFetcher $fallbackSemanticDataFetcher
 	 */
-	public function __construct( LazySemanticDataFetcher $lazySemanticDataFetcher ) {
-		$this->lazySemanticDataFetcher = $lazySemanticDataFetcher;
+	public function __construct( FallbackSemanticDataFetcher $fallbackSemanticDataFetcher ) {
+		$this->fallbackSemanticDataFetcher = $fallbackSemanticDataFetcher;
 	}
 
 	/**
@@ -50,7 +50,7 @@ class PropertyValueContentFinder {
 	private function findContentForProperty( $property, &$values ) {
 
 		$property = DIProperty::newFromUserLabel( $property );
-		$semanticData = $this->lazySemanticDataFetcher->getSemanticData();
+		$semanticData = $this->fallbackSemanticDataFetcher->getSemanticData();
 
 		$this->iterateOverPropertyValues(
 			$semanticData->getPropertyValues( $property ),

--- a/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
+++ b/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
@@ -43,7 +43,8 @@ class MetaTagsContentGenerationIntegrationTest extends MwDBaseUnitTestCase {
 		$configuration = array(
 			'metaTagsContentPropertySelector' => $metaTagsContentPropertySelector,
 			'metaTagsStaticContentDescriptor' => $metaTagsStaticContentDescriptor,
-			'metaTagsBlacklist' => array()
+			'metaTagsBlacklist' => array(),
+			'metaTagsMultiplePropertiesToUseForFallback' => false
 		);
 
 		$hookRegistry = new HookRegistry( $configuration );

--- a/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
+++ b/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
@@ -42,7 +42,8 @@ class MetaTagsContentGenerationIntegrationTest extends MwDBaseUnitTestCase {
 
 		$configuration = array(
 			'metaTagsContentPropertySelector' => $metaTagsContentPropertySelector,
-			'metaTagsStaticContentDescriptor' => $metaTagsStaticContentDescriptor
+			'metaTagsStaticContentDescriptor' => $metaTagsStaticContentDescriptor,
+			'metaTagsBlacklist' => array()
 		);
 
 		$hookRegistry = new HookRegistry( $configuration );

--- a/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
+++ b/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
@@ -44,7 +44,7 @@ class MetaTagsContentGenerationIntegrationTest extends MwDBaseUnitTestCase {
 			'metaTagsContentPropertySelector' => $metaTagsContentPropertySelector,
 			'metaTagsStaticContentDescriptor' => $metaTagsStaticContentDescriptor,
 			'metaTagsBlacklist' => array(),
-			'metaTagsMultiplePropertiesToUseForFallback' => false
+			'metaTagsFallbackUseForMultipleProperties' => false
 		);
 
 		$hookRegistry = new HookRegistry( $configuration );

--- a/tests/phpunit/Unit/FallbackSemanticDataFetcherTest.php
+++ b/tests/phpunit/Unit/FallbackSemanticDataFetcherTest.php
@@ -2,11 +2,11 @@
 
 namespace SMT\Tests;
 
-use SMT\LazySemanticDataFetcher;
+use SMT\FallbackSemanticDataFetcher;
 use SMW\DIWikiPage;
 
 /**
- * @covers \SMT\LazySemanticDataFetcher
+ * @covers \SMT\FallbackSemanticDataFetcher
  *
  * @group semantic-meta-tags
  *
@@ -15,7 +15,7 @@ use SMW\DIWikiPage;
  *
  * @author mwjames
  */
-class LazySemanticDataFetcherTest extends \PHPUnit_Framework_TestCase {
+class FallbackSemanticDataFetcherTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
@@ -28,8 +28,8 @@ class LazySemanticDataFetcherTest extends \PHPUnit_Framework_TestCase {
 			->getMockForAbstractClass();
 
 		$this->assertInstanceOf(
-			'\SMT\LazySemanticDataFetcher',
-			new LazySemanticDataFetcher( $parserData, $store )
+			'\SMT\FallbackSemanticDataFetcher',
+			new FallbackSemanticDataFetcher( $parserData, $store )
 		);
 	}
 
@@ -58,7 +58,7 @@ class LazySemanticDataFetcherTest extends \PHPUnit_Framework_TestCase {
 		$store->expects( $this->never() )
 			->method( 'getSemanticData' );
 
-		$instance = new LazySemanticDataFetcher( $parserData, $store );
+		$instance = new FallbackSemanticDataFetcher( $parserData, $store );
 		$instance->getSemanticData();
 
 		// Internally cached
@@ -98,7 +98,7 @@ class LazySemanticDataFetcherTest extends \PHPUnit_Framework_TestCase {
 		$store->expects( $this->once() )
 			->method( 'getSemanticData' );
 
-		$instance = new LazySemanticDataFetcher( $parserData, $store );
+		$instance = new FallbackSemanticDataFetcher( $parserData, $store );
 		$instance->getSemanticData();
 
 		// Internally cached

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -32,7 +32,8 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 		$configuration = array(
 			'metaTagsContentPropertySelector' => array(),
 			'metaTagsStaticContentDescriptor' => array(),
-			'metaTagsBlacklist' => array()
+			'metaTagsBlacklist' => array(),
+			'metaTagsMultiplePropertiesToUseForFallback' => false
 		);
 
 		$instance = new HookRegistry( $configuration );

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -31,7 +31,8 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 
 		$configuration = array(
 			'metaTagsContentPropertySelector' => array(),
-			'metaTagsStaticContentDescriptor' => array()
+			'metaTagsStaticContentDescriptor' => array(),
+			'metaTagsBlacklist' => array()
 		);
 
 		$instance = new HookRegistry( $configuration );

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -33,7 +33,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			'metaTagsContentPropertySelector' => array(),
 			'metaTagsStaticContentDescriptor' => array(),
 			'metaTagsBlacklist' => array(),
-			'metaTagsMultiplePropertiesToUseForFallback' => false
+			'metaTagsFallbackUseForMultipleProperties' => false
 		);
 
 		$instance = new HookRegistry( $configuration );

--- a/tests/phpunit/Unit/OutputPageTagFormatterTest.php
+++ b/tests/phpunit/Unit/OutputPageTagFormatterTest.php
@@ -56,6 +56,21 @@ class OutputPageTagFormatterTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testTryToAddContentForBlacklistedTag() {
+
+		$outputPage = $this->getMockBuilder( '\OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$outputPage->expects( $this->never() )
+			->method( 'addMeta' );
+
+		$instance = new OutputPageTagFormatter( $outputPage );
+		$instance->setMetaTagsBlacklist( array( 'foo' ) );
+
+		$instance->addTagContentToOutputPage( 'FOO', 'bar' );
+	}
+
 	/**
 	 * @dataProvider nonOgTagProvider
 	 */

--- a/tests/phpunit/Unit/PropertyValueContentFinderTest.php
+++ b/tests/phpunit/Unit/PropertyValueContentFinderTest.php
@@ -196,7 +196,7 @@ class PropertyValueContentFinderTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( $semanticData ) );
 
 		$instance = new PropertyValueContentFinder( $fallbackSemanticDataFetcher );
-		$instance->setMultiplePropertiesToUseForFallback( $fallbackChainUsageState );
+		$instance->useFallbackChainForMultipleProperties( $fallbackChainUsageState );
 
 		$this->assertSame(
 			$expected,

--- a/tests/phpunit/Unit/PropertyValueContentFinderTest.php
+++ b/tests/phpunit/Unit/PropertyValueContentFinderTest.php
@@ -22,13 +22,13 @@ class PropertyValueContentFinderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
-		$lazySemanticDataFetcher = $this->getMockBuilder( '\SMT\LazySemanticDataFetcher' )
+		$fallbackSemanticDataFetcher = $this->getMockBuilder( '\SMT\FallbackSemanticDataFetcher' )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->assertInstanceOf(
 			'\SMT\PropertyValueContentFinder',
-			new PropertyValueContentFinder( $lazySemanticDataFetcher )
+			new PropertyValueContentFinder( $fallbackSemanticDataFetcher )
 		);
 	}
 
@@ -49,15 +49,15 @@ class PropertyValueContentFinderTest extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( DIProperty::newFromUserLabel( 'foobar' ) ) )
 			->will( $this->returnValue( array( new DIWikiPage( 'Foo', NS_MAIN ) ) ) );
 
-		$lazySemanticDataFetcher = $this->getMockBuilder( '\SMT\LazySemanticDataFetcher' )
+		$fallbackSemanticDataFetcher = $this->getMockBuilder( '\SMT\FallbackSemanticDataFetcher' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$lazySemanticDataFetcher->expects( $this->once() )
+		$fallbackSemanticDataFetcher->expects( $this->once() )
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
-		$instance = new PropertyValueContentFinder( $lazySemanticDataFetcher );
+		$instance = new PropertyValueContentFinder( $fallbackSemanticDataFetcher );
 
 		$this->assertSame(
 			'Foo',
@@ -90,15 +90,15 @@ class PropertyValueContentFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSubSemanticData' )
 			->will( $this->returnValue( array( $subSemanticData ) ) );
 
-		$lazySemanticDataFetcher = $this->getMockBuilder( '\SMT\LazySemanticDataFetcher' )
+		$fallbackSemanticDataFetcher = $this->getMockBuilder( '\SMT\FallbackSemanticDataFetcher' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$lazySemanticDataFetcher->expects( $this->once() )
+		$fallbackSemanticDataFetcher->expects( $this->once() )
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
-		$instance = new PropertyValueContentFinder( $lazySemanticDataFetcher );
+		$instance = new PropertyValueContentFinder( $fallbackSemanticDataFetcher );
 
 		$this->assertSame(
 			'Foo-with-html-"<>"-escaping-to-happen-somewhere-else',
@@ -132,15 +132,15 @@ class PropertyValueContentFinderTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSubSemanticData' )
 			->will( $this->returnValue( array() ) );
 
-		$lazySemanticDataFetcher = $this->getMockBuilder( '\SMT\LazySemanticDataFetcher' )
+		$fallbackSemanticDataFetcher = $this->getMockBuilder( '\SMT\FallbackSemanticDataFetcher' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$lazySemanticDataFetcher->expects( $this->atLeastOnce() )
+		$fallbackSemanticDataFetcher->expects( $this->atLeastOnce() )
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
-		$instance = new PropertyValueContentFinder( $lazySemanticDataFetcher );
+		$instance = new PropertyValueContentFinder( $fallbackSemanticDataFetcher );
 
 		$this->assertSame(
 			'http://username@example.org/foo,"Foo",Mo,fo',


### PR DESCRIPTION
- Renamed `egSMTMetaTagsContentPropertySelector` to `smtgTagsContentPropertySelector`
- Renamed `egSMTMetaTagsStaticContentDescriptor` to `smtgTagsStaticContentDescriptor`
- Added `smtgFallbackUseForMultipleProperties` refs #21
- Added `smtgTagsBlacklist`