### PR TITLE
FEAT: http-equiv meta tags

### DIFF
--- a/src/OutputPageHtmlTagsInserter.php
+++ b/src/OutputPageHtmlTagsInserter.php
@@ -106,6 +106,10 @@ class OutputPageHtmlTagsInserter {
 			return $this->addMetaPropertyMarkup( $tag, $content );
 		}
 
+		if ( $this->reqMetaHttpEquivs( $tag ) ) {
+			return $this->addMetaHttpEquivMarkup( $tag, $content );
+		}
+
 		$this->outputPage->addMeta( $tag, $content );
 	}
 
@@ -139,5 +143,31 @@ class OutputPageHtmlTagsInserter {
 
 		return false;
 	}
+
+	private function reqMetaHttpEquivs( $tag ) {
+
+		// If a tag contains a `og:` such as `og:title` it is expected to be a
+		// OpenGraph protocol tag along with other prefixes maintained in
+		// $GLOBALS['smtgMetaPropertyPrefixes']
+		return in_array( $tag, $GLOBALS['smtgMetaHttpEquivs'] );
+	}
+
+	private function addMetaHttpEquivMarkup( $tag, $content ) {
+
+		$comment = '';
+
+		if ( !$this->metaPropertyMarkup ) {
+			$comment .= '<!-- Semantic MetaTags -->' . "\n";
+			$this->metaPropertyMarkup = true;
+		}
+
+		$content = $comment . \Html::element( 'meta', [
+			'http-equiv' => $tag,
+			'content'  => $content
+		] );
+
+		$this->outputPage->addHeadItem( "meta:property:$tag", $content );
+	}
+
 
 }


### PR DESCRIPTION
That is a quick'n dirty implementation to output `<meta http-equiv="...">` tags.
The above html element gets produces only for those tags in `smtgTagsProperties` that exist also in the new `smtgMetaHttpEquivs` GLOBALS array.

* There is no documentation, apart from this description here.
* The existing structure of the projects has not been honored - only the `src/OutputPageHtmlTagsInserter.php` file was modified.
* It is provided just as a starting base.