### PR TITLE
Switch to extension registration mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,20 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=REL1_28; TYPE=coverage
+    - env: DB=mysql; MW=master; SMW=~3.1@dev; PHPUNIT=6.5.*
+      php: 7.3
+    - env: DB=mysql; MW=REL1_31; SMW=~3.0@dev; PHPUNIT=6.5.*
+      php: 7.0
+    - env: DB=sqlite; MW=REL1_27; SMW=~3.0@dev; SITELANG=ja
       php: 5.6
-    - env: DB=sqlite; MW=REL1_27; SITELANG=ja
-      php: 5.6
-    - env: DB=sqlite; MW=master; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=REL1_28; SMW=~3.0@dev; TYPE=coverage
+      php: 7.0
+    - env: DB=sqlite; MW=REL1_29; SMW=~3.0@dev; PHPUNIT=4.8.*
       php: 7.1
+    - env: DB=postgres; MW=REL1_30; SMW=~3.0@dev; PHPUNIT=5.7.*
+      php: 7.2      
   allow_failures:
-     - env: DB=sqlite; MW=master; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=master; SMW=~3.1@dev; PHPUNIT=6.5.*
 
 install:
   - bash ./tests/travis/install-mediawiki.sh

--- a/SemanticMetaTags.php
+++ b/SemanticMetaTags.php
@@ -9,14 +9,6 @@ use SMW\ApplicationFactory;
  *
  * @defgroup SMT Semantic Meta Tags
  */
-if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'This file is part of the Semantic Meta Tags extension, it is not a valid entry point.' );
-}
-
-if ( defined( 'SMT_VERSION' ) ) {
-	// Do not initialize more than once.
-	return 1;
-}
 
 SemanticMetaTags::load();
 
@@ -41,32 +33,12 @@ class SemanticMetaTags {
 			include_once __DIR__ . '/vendor/autoload.php';
 		}
 
-		// In case extension.json is being used, the succeeding steps will
-		// be handled by the ExtensionRegistry
-		self::initExtension();
-
-		$GLOBALS['wgExtensionFunctions'][] = function() {
-			self::onExtensionFunction();
-		};
 	}
 
 	/**
 	 * @since 1.0
 	 */
 	public static function initExtension() {
-
-		define( 'SMT_VERSION', '2.0.0-alpha' );
-
-		// Register extension info
-		$GLOBALS['wgExtensionCredits']['semantic'][] = [
-			'path'           => __FILE__,
-			'name'           => 'Semantic Meta Tags',
-			'author'         => [ 'James Hong Kong' ],
-			'url'            => 'https://github.com/SemanticMediaWiki/SemanticMetaTags/',
-			'descriptionmsg' => 'smt-desc',
-			'version'        => SMT_VERSION,
-			'license-name'   => 'GPL-2.0-or-later',
-		];
 
 		// Register message files
 		$GLOBALS['wgMessagesDirs']['SemanticMetaTags'] = __DIR__ . '/i18n';
@@ -87,8 +59,18 @@ class SemanticMetaTags {
 	 */
 	public static function onExtensionFunction() {
 
-		// Check requirements after LocalSetting.php has been processed
-		self::doCheckRequirements();
+		if ( !defined( 'SMW_VERSION' ) ) {
+
+			if ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) {
+				die( "\nThe 'Semantic Meta Tags' extension requires 'Semantic MediaWiki' to be installed and enabled.\n" );
+			} else {
+				die(
+					'<b>Error:</b> The <a href="https://www.semantic-mediawiki.org/wiki/Extension:Semantic Meta Tags">Semantic Meta Tags</a> ' .
+					'extension requires <a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki">Semantic MediaWiki</a> to be ' .
+					'installed and enabled.<br>'
+				);
+			}
+		}
 
 		$configuration = [
 			'metaTagsContentPropertySelector' => $GLOBALS['smtgTagsProperties'],
@@ -103,7 +85,6 @@ class SemanticMetaTags {
 			new Options( $configuration )
 		);
 
-		$hookRegistry->register();
 	}
 
 	/**

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,26 @@
+{
+	"name": "SemanticMetaTags",
+	"version": "2.0.0-alpha",
+	"author": [
+		"James Hong Kong"
+	],
+	"url": "https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Meta_Tags",
+	"descriptionmsg": "smt-desc",
+	"namemsg": "smt-name",
+	"license-name": "GPL-2.0-or-later",
+	"type": "semantic",
+	"requires": {
+		"MediaWiki": ">= 1.27"
+	},
+	"MessagesDirs": {
+		"SemanticMetaTags": [
+			"i18n"
+		]
+	},
+	"callback": "SemanticMetaTags::initExtension",
+	"ExtensionFunctions": [
+		"SemanticMetaTags::onExtensionFunction"
+	],
+	"load_composer_autoloader": true,
+	"manifest_version": 1
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,8 +1,10 @@
 {
 	"@metadata": {
 		"authors": [
-			"mwjames"
+			"mwjames",
+			"kghbln"
 		]
 	},
-	"smt-desc": "Allows to provide meta tags generated from [https://semantic-mediawiki.org semantic annotations]"
+	"smt-desc": "Allows to provide meta tags generated from [https://www.semantic-mediawiki.org semantic annotations]",
+	"smt-name": "Semantic Meta Tags"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -5,5 +5,6 @@
 			"Kghbln"
 		]
 	},
-	"smt-desc": "{{desc|name=Semantic Meta Tags|url=https://www.mediawiki.org/wiki/Extension:Semantic_Meta_Tags}}\nAn extension providing HTML <meta> tags generated from semantic annotations."
+	"smt-desc": "{{desc|name=Semantic Meta Tags|url=https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Meta_Tags}}\nAn extension providing HTML <meta> tags generated from semantic annotations.",
+	"smt-name": "The name of this extension.\n{{Notranslate}}"
 }

--- a/tests/travis/install-semantic-meta-tags.sh
+++ b/tests/travis/install-semantic-meta-tags.sh
@@ -51,6 +51,11 @@ function updateConfiguration {
 
 	cd $MW_INSTALL_PATH
 
+	# SMW#1732
+	echo 'wfLoadExtension( "SemanticMediaWiki" );' >> LocalSettings.php
+
+	echo 'wfLoadExtension( "SemanticMetaTags" );' >> LocalSettings.php
+
 	# Site language
 	if [ "$SITELANG" != "" ]
 	then


### PR DESCRIPTION
This PR is made in reference to: #48 

This PR addresses or contains:
- Switches to extension registration mechanism
- Obsoletes https://github.com/SemanticMediaWiki/SemanticMetaTags/pull/43

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes: #48 