### PR TITLE
This change addresses the feature request #61.

### DIFF
--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -94,7 +94,8 @@ class HookRegistry {
 			);
 
 			$propertyValuesContentAggregator = new PropertyValuesContentAggregator(
-				$lazySemanticDataLookup
+				$lazySemanticDataLookup,
+				$outputPage
 			);
 
 			$propertyValuesContentAggregator->useFallbackChainForMultipleProperties(

--- a/src/MetaTagsProcessor.php
+++ b/src/MetaTagsProcessor.php
@@ -90,6 +90,8 @@ class MetaTagsProcessor {
 
 		if ( is_string( $properties ) ) {
 			$properties = explode( ',', $properties );
+		} elseif ( is_callable( $properties ) ) {
+			$properties = [ $properties ];
 		}
 
 		$content = $this->propertyValuesContentAggregator->doAggregateFor(

--- a/src/PropertyValuesContentAggregator.php
+++ b/src/PropertyValuesContentAggregator.php
@@ -21,6 +21,11 @@ class PropertyValuesContentAggregator {
 	private $lazySemanticDataLookup;
 
 	/**
+	 * @var OutputPage $mOutputPage
+	 */
+	private $mOutputPage;
+
+	/**
 	 * Whether multiple properties should be used through a fallback chain where
 	 * the first available property with content will determine the end of the
 	 * processing or content being simply concatenated
@@ -33,9 +38,11 @@ class PropertyValuesContentAggregator {
 	 * @since 1.0
 	 *
 	 * @param LazySemanticDataLookup $lazySemanticDataLookup
+	 * @param OutputPage $outputPage
 	 */
-	public function __construct( LazySemanticDataLookup $lazySemanticDataLookup ) {
+	public function __construct( LazySemanticDataLookup $lazySemanticDataLookup, \OutputPage $outputPage ) {
 		$this->lazySemanticDataLookup = $lazySemanticDataLookup;
+		$this->mOutputPage = $outputPage;
 	}
 
 	/**
@@ -66,27 +73,41 @@ class PropertyValuesContentAggregator {
 				break;
 			}
 
-			$this->fetchContentForProperty( trim( $property ), $values );
+			if ( is_string( $property ) ) {
+				$property = trim( $property );
+			}
+			$this->fetchContentForProperty( $property, $values );
 		}
 
 		return implode( ',', $values );
 	}
 
-	private function fetchContentForProperty( $property, &$values ) {
+	private function fetchContentForProperty( $property, array &$values ) {
 
-		$property = DIProperty::newFromUserLabel( $property );
-		$semanticData = $this->lazySemanticDataLookup->getSemanticData();
+		if ( is_callable( $property ) ) {
+			// This is actually a callback function.
+			$result = $property( $this->mOutputPage );
+			if ( $result ) {
+				foreach ( (array)$result as $value ) {
+					$values[$value] = (string)$value;
+				}
+			}
+		} else {
+			// This is a real property.
+			$property = DIProperty::newFromUserLabel( $property );
+			$semanticData = $this->lazySemanticDataLookup->getSemanticData();
 
-		$this->iterateToCollectPropertyValues(
-			$semanticData->getPropertyValues( $property ),
-			$values
-		);
-
-		foreach ( $semanticData->getSubSemanticData() as $subSemanticData ) {
 			$this->iterateToCollectPropertyValues(
-				$subSemanticData->getPropertyValues( $property ),
+				$semanticData->getPropertyValues( $property ),
 				$values
 			);
+
+			foreach ( $semanticData->getSubSemanticData() as $subSemanticData ) {
+				$this->iterateToCollectPropertyValues(
+					$subSemanticData->getPropertyValues( $property ),
+					$values
+				);
+			}
 		}
 	}
 

--- a/src/PropertyValuesContentAggregator.php
+++ b/src/PropertyValuesContentAggregator.php
@@ -21,7 +21,7 @@ class PropertyValuesContentAggregator {
 	private $lazySemanticDataLookup;
 
 	/**
-	 * @var OutputPage $mOutputPage
+	 * @var \OutputPage $mOutputPage
 	 */
 	private $mOutputPage;
 

--- a/tests/phpunit/Unit/PropertyValuesContentAggregatorTest.php
+++ b/tests/phpunit/Unit/PropertyValuesContentAggregatorTest.php
@@ -25,9 +25,13 @@ class PropertyValuesContentAggregatorTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$outputPage = $this->getMockBuilder( 'OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->assertInstanceOf(
 			'\SMT\PropertyValuesContentAggregator',
-			new PropertyValuesContentAggregator( $lazySemanticDataLookup )
+			new PropertyValuesContentAggregator( $lazySemanticDataLookup, $outputPage )
 		);
 	}
 
@@ -56,7 +60,11 @@ class PropertyValuesContentAggregatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
-		$instance = new PropertyValuesContentAggregator( $lazySemanticDataLookup );
+		$outputPage = $this->getMockBuilder( 'OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyValuesContentAggregator( $lazySemanticDataLookup, $outputPage );
 
 		$this->assertSame(
 			'Foo',
@@ -93,7 +101,11 @@ class PropertyValuesContentAggregatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
-		$instance = new PropertyValuesContentAggregator( $lazySemanticDataLookup );
+		$outputPage = $this->getMockBuilder( 'OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyValuesContentAggregator( $lazySemanticDataLookup, $outputPage );
 
 		$this->assertSame(
 			'http://username@example.org/foo,Foo',
@@ -134,7 +146,11 @@ class PropertyValuesContentAggregatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
-		$instance = new PropertyValuesContentAggregator( $lazySemanticDataLookup );
+		$outputPage = $this->getMockBuilder( 'OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyValuesContentAggregator( $lazySemanticDataLookup, $outputPage );
 
 		$this->assertSame(
 			'Foo-with-html-"<>"-escaping-to-happen-somewhere-else',
@@ -230,7 +246,11 @@ class PropertyValuesContentAggregatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getSemanticData' )
 			->will( $this->returnValue( $semanticData ) );
 
-		$instance = new PropertyValuesContentAggregator( $lazySemanticDataLookup );
+		$outputPage = $this->getMockBuilder( 'OutputPage' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new PropertyValuesContentAggregator( $lazySemanticDataLookup, $outputPage );
 		$instance->useFallbackChainForMultipleProperties( $fallbackChainUsageState );
 
 		$this->assertSame(


### PR DESCRIPTION
This PR is made in reference to: #61

$smtgTagsProperties now allows callables among property names.

The callable is called and its return(s) are added to the tag values,
as if they were property values.

The callable is passed ( OutputPage $outputPage ), which allows access
to the current page metadata, like its title, canonical URL
or incoming redirects.

The messages are also fully initialised by the point the callable
is invoked.

Example:
```php
$smtgTagsProperties = [
	'keywords' => [ 'Has keyword', function( OutputPage $outputPage ) {
		// Redirects to the page are collected as keywords.
		$redirects = $outputPage->getContext()->getTitle()->getRedirectsHere();
		$redirect_titles = [];
		foreach ( $redirects as $redirect ) {
			$redirect_titles[] = $redirect->getText();
		}
		return implode( ', ', array_unique( $redirect_titles ));
	} ]
];
```

This PR includes:
- [ ] Tests (unit/integration)