### PR TITLE
adds json-ld serialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
 	"require": {
 		"php": ">=7.1",
 		"composer/installers": "1.*,>=1.0.1",
-		"mediawiki/semantic-media-wiki": "~3.1|~4.0",
-		"easyrdf/easyrdf": "*",
+		"mediawiki/semantic-media-wiki": "~3.1|~4.0|~5.0",
+		"easyrdf/easyrdf": "~1.1",
 		"ml/json-ld": "^1.2"
 	},
 	"require-dev": {
@@ -53,7 +53,10 @@
 		}
 	},
 	"config": {
-		"process-timeout": 0
+		"process-timeout": 0,
+		"allow-plugins": {
+			"composer/installers": false
+		}
 	},
 	"scripts":{
 		"test": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,9 @@
 	"require": {
 		"php": ">=7.1",
 		"composer/installers": "1.*,>=1.0.1",
-		"mediawiki/semantic-media-wiki": "~3.1|~4.0"
+		"mediawiki/semantic-media-wiki": "~3.1|~4.0",
+		"easyrdf/easyrdf": "*",
+		"ml/json-ld": "^1.2"
 	},
 	"require-dev": {
 		"mediawiki/semantic-media-wiki": "@dev",

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -63,7 +63,7 @@ class HookRegistry {
 	private function addCallbackHandlers( $store, $options ) {
 
 		$this->handlers['BeforePageDisplay'] = function ( $outputPage, $skin ) {
-			if ( !isset( $GLOBALS['wgSemanticMetaTagsDisableJsonLD'] ) ) {
+			if ( empty( $GLOBALS['wgSemanticMetaTagsDisableJsonLD'] ) ) {
 				new JsonLDSerializer( $skin->getTitle(), $outputPage );
 			}
 		};

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -62,6 +62,12 @@ class HookRegistry {
 
 	private function addCallbackHandlers( $store, $options ) {
 
+		$this->handlers['BeforePageDisplay'] = function ( $outputPage, $skin ) {
+			if ( !isset( $GLOBALS['wgSemanticMetaTagsDisableJsonLD'] ) ) {
+				new JsonLDSerializer( $skin->getTitle(), $outputPage );
+			}
+		};
+
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/OutputPageParserOutput
 		 */

--- a/src/JsonLDSerializer.php
+++ b/src/JsonLDSerializer.php
@@ -1,15 +1,16 @@
 <?php
 
+/**
+ * @see  https://www.mediawiki.org/wiki/Extension:PageProperties
+ * @author thomas-topway-it for Km-a
+ */
+
 namespace SMT;
 
 use Title;
 use OutputPage;
 use SpecialPage;
 use Html;
-
-/**
- * @credits https://www.mediawiki.org/wiki/Extension:PageProperties 
- */
 
 class JsonLDSerializer {
 	/**

--- a/src/JsonLDSerializer.php
+++ b/src/JsonLDSerializer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SMT;
+
+use Title;
+use OutputPage;
+use SpecialPage;
+use Html;
+
+/**
+ * @credits https://www.mediawiki.org/wiki/Extension:PageProperties 
+ */
+
+class JsonLDSerializer {
+	/**
+	 * @param Title $title
+	 * @param OutputPage $outputPage
+	 */
+	public function __construct( $title, $outputPage ) {
+		if ( $this->isKnownArticle( $title ) ) {
+			$this->setJsonLD( $title, $outputPage );
+		}
+	}
+
+	/**
+	 * @see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/PageProperties/+/548d30609c512a79e202dfa7c02a298c66ca34fa/includes/PageProperties.php
+	 * @param Title $title
+	 * @return bool
+	 */
+	private function isKnownArticle( $title ) {
+		return ( $title && $title->canExist() && $title->getArticleID() > 0
+			&& $title->isKnown() );
+	}
+
+	/**
+	 * @see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/PageProperties/+/548d30609c512a79e202dfa7c02a298c66ca34fa/includes/PageProperties.php
+	 * @param Title $title
+	 * @param OutputPage $outputPage
+	 * @return void
+	 */
+	public static function setJsonLD( $title, $outputPage ) {
+		if ( !class_exists( '\EasyRdf\Graph' ) || !class_exists( '\ML\JsonLD\JsonLD' ) ) {
+			return;
+		}
+
+		// @TODO use directly the function makeExportDataForSubject
+		// SemanticMediawiki/includes/export/SMW_Exporter.php
+		$export_rdf = SpecialPage::getTitleFor( 'ExportRDF' );
+		if ( $export_rdf->isKnown() ) {
+			$export_url = $export_rdf->getFullURL( [
+				'page' => $title->getFullText(),
+				'recursive' => '1',
+				'backlinks' => 0
+			] );
+
+			try {
+				$foaf = new \EasyRdf\Graph( $export_url );
+				$foaf->load();
+
+				$format = \EasyRdf\Format::getFormat( 'jsonld' );
+				$output = $foaf->serialise( $format, [
+					'compact' => true,
+				] );
+
+			} catch ( Exception $e ) {
+				self::$Logger->error( 'EasyRdf error: ' . $export_url );
+				return;
+			}
+
+			// https://hotexamples.com/examples/-/EasyRdf_Graph/serialise/php-easyrdf_graph-serialise-method-examples.html
+			if ( is_scalar( $output ) ) {
+				$outputPage->addHeadItem( 'json-ld', Html::Element(
+						'script', [ 'type' => 'application/ld+json' ], $output
+					)
+				);
+			}
+		}
+	}
+}

--- a/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
+++ b/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
@@ -29,6 +29,10 @@ class MetaTagsContentGenerationIntegrationTest extends MwDBaseUnitTestCase {
 		$this->pageCreator = UtilityFactory::getInstance()->newpageCreator();
 		$this->pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
 
+		$this->mwHooksHandler = $this->testEnvironment->getUtilityFactory()->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+		$this->mwHooksHandler->invokeHooksFromRegistry();
+
 		$metaTagsBlacklist = [
 			'robots'
 		];

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -69,7 +69,7 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$context->expects( $this->atLeastOnce() )
+		$context->expects( $this->any() )
 			->method( 'getRequest' )
 			->will( $this->returnValue( $webRequest ) );
 


### PR DESCRIPTION
adds json-ld serialization using https://github.com/easyrdf/easyrdf
from SMW's standard RDF serialization


for testing purpose run `composer install` in the extension folder after merging the pull request https://github.com/SemanticMediaWiki/SemanticMetaTags/pull/79