### PR TITLE
Fix composer autoload

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -17,19 +17,19 @@ if ( !defined( 'MEDIAWIKI' ) ) {
  *
  * 'keywords' => array( 'Has keywords', ... )
  */
-$GLOBALS['smtgTagsProperties'] = [];
+$GLOBALS['smtgTagsProperties'] = $GLOBALS['smtgTagsProperties'] ?? [];
 
 /**
  * Describes static content for an assigned `<meta>` tag
  *
  * 'some:tag' => 'Content that is static'
  */
-$GLOBALS['smtgTagsStrings'] = [];
+$GLOBALS['smtgTagsStrings'] = $GLOBALS['smtgTagsStrings'] ?? [];
 
 /**
  * Listed tags are generally assumed to be reserved or excluded for free use
  */
-$GLOBALS['smtgTagsBlacklist'] = [
+$GLOBALS['smtgTagsBlacklist'] = $GLOBALS['smtgTagsBlacklist'] ?? [
 	'generator',
 	'robots'
 ];
@@ -38,9 +38,9 @@ $GLOBALS['smtgTagsBlacklist'] = [
  * In case it is set `true` then the first property that returns a valid content
  * for an assigned tag will be used  exclusively.
  */
-$GLOBALS['smtgTagsPropertyFallbackUsage'] = false;
+$GLOBALS['smtgTagsPropertyFallbackUsage'] = $GLOBALS['smtgTagsPropertyFallbackUsage'] ?? false;
 
 /**
  * Identifies prefixes that require `meta:property:...`
  */
-$GLOBALS['smtgMetaPropertyPrefixes'] = [ 'og:' ];
+$GLOBALS['smtgMetaPropertyPrefixes'] = $GLOBALS['smtgMetaPropertyPrefixes'] ?? [ 'og:' ];

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
 		"composer/installers": "1.*,>=1.0.1"	
 	},
 	"require-dev": {
-		"mediawiki/semantic-media-wiki": "@dev",
 		"squizlabs/php_codesniffer": "~2.1",
 		"phpmd/phpmd": "~2.1"
 	},
@@ -40,17 +39,12 @@
 			"dev-master": "3.x-dev"
 		}
 	},
-	"autoload": {
-		"files" : [
-			"DefaultSettings.php",
-			"SemanticMetaTags.php"
-		],
-		"psr-4": {
-			"SMT\\": "src/"
-		}
-	},
+	"autoload": {},
 	"config": {
-		"process-timeout": 0
+		"process-timeout": 0,
+		"allow-plugins": {
+			"composer/installers": true
+		}
 	},
 	"scripts":{
 		"test": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,7 @@
 	},
 	"require": {
 		"php": ">=7.1",
-		"composer/installers": "1.*,>=1.0.1",
-		"easyrdf/easyrdf": "*",
-		"ml/json-ld": "^1.2"
+		"composer/installers": "1.*,>=1.0.1"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.1",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
 	},
 	"require": {
 		"php": ">=7.1",
-		"composer/installers": "1.*,>=1.0.1"	
+		"composer/installers": "1.*,>=1.0.1",
+		"easyrdf/easyrdf": "*",
+		"ml/json-ld": "^1.2"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "~2.1",

--- a/extension.json
+++ b/extension.json
@@ -20,6 +20,12 @@
 			"i18n"
 		]
 	},
+	"AutoloadNamespaces": {
+		"SMT\\": "src"
+	},
+	"AutoloadClasses": {
+		"SemanticMetaTags": "SemanticMetaTags.php"
+	},
 	"callback": "SemanticMetaTags::initExtension",
 	"ExtensionFunctions": [
 		"SemanticMetaTags::onExtensionFunction"

--- a/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
+++ b/tests/phpunit/Integration/MetaTagsContentGenerationIntegrationTest.php
@@ -29,6 +29,11 @@ class MetaTagsContentGenerationIntegrationTest extends MwDBaseUnitTestCase {
 		$this->pageCreator = UtilityFactory::getInstance()->newpageCreator();
 		$this->pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
 
+		// @see LinksUpdateTest
+		$this->mwHooksHandler = $this->testEnvironment->getUtilityFactory()->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+		$this->mwHooksHandler->invokeHooksFromRegistry();
+
 		$metaTagsBlacklist = [
 			'robots'
 		];

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -69,7 +69,8 @@ class HookRegistryTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$context->expects( $this->atLeastOnce() )
+		// *** conform SMW 'getRequest' tests
+		$context->expects( $this->any() )
 			->method( 'getRequest' )
 			->will( $this->returnValue( $webRequest ) );
 


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticMetaTags/issues/76

> This file is part of the SemanticMetaTags extension, it is not a valid entry point


* Moves extension autoload from `composer.json` to `extension.json`
* Remove redundant `semantic-media-wiki` require to allow running composer in the extension folder

(manual rebase of https://github.com/SemanticMediaWiki/SemanticMetaTags/pull/79)