### PR TITLE
Json ld serialization updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,10 @@
 	},
 	"require": {
 		"php": ">=7.4",
-		"composer/installers": ">=1.0.1"
+		"composer/installers": ">=1.0.1",
+		"mediawiki/semantic-media-wiki": "~3.1|~4.0|~5.0",
+		"easyrdf/easyrdf": "~1.1",
+		"ml/json-ld": "^1.2"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "43.0.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
 	"require": {
 		"php": ">=7.4",
 		"composer/installers": ">=1.0.1",
-		"mediawiki/semantic-media-wiki": "~3.1|~4.0|~5.0",
 		"easyrdf/easyrdf": "~1.1",
 		"ml/json-ld": "^1.2"
 	},

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -61,6 +61,13 @@ class HookRegistry {
 	}
 
 	private function addCallbackHandlers( $store, $options ) {
+
+		$this->handlers['BeforePageDisplay'] = function ( $outputPage, $skin ) {
+			if ( empty( $GLOBALS['wgSemanticMetaTagsDisableJsonLD'] ) ) {
+				new JsonLDSerializer( $skin->getTitle(), $outputPage );
+			}
+		};
+
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/OutputPageParserOutput
 		 */

--- a/src/HookRegistry.php
+++ b/src/HookRegistry.php
@@ -61,8 +61,7 @@ class HookRegistry {
 	}
 
 	private function addCallbackHandlers( $store, $options ) {
-
-		$this->handlers['BeforePageDisplay'] = function ( $outputPage, $skin ) {
+		$this->handlers['BeforePageDisplay'] = static function ( $outputPage, $skin ) {
 			if ( empty( $GLOBALS['wgSemanticMetaTagsDisableJsonLD'] ) ) {
 				new JsonLDSerializer( $skin->getTitle(), $outputPage );
 			}

--- a/src/JsonLDSerializer.php
+++ b/src/JsonLDSerializer.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @see  https://www.mediawiki.org/wiki/Extension:PageProperties
+ * @author thomas-topway-it for KM-A
+ */
+
+namespace SMT;
+
+use Title;
+use OutputPage;
+use SpecialPage;
+use Html;
+
+class JsonLDSerializer {
+	/**
+	 * @param Title $title
+	 * @param OutputPage $outputPage
+	 */
+	public function __construct( $title, $outputPage ) {
+		if ( $this->isKnownArticle( $title ) ) {
+			$this->setJsonLD( $title, $outputPage );
+		}
+	}
+
+	/**
+	 * @see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/PageProperties/+/548d30609c512a79e202dfa7c02a298c66ca34fa/includes/PageProperties.php
+	 * @param Title $title
+	 * @return bool
+	 */
+	private function isKnownArticle( $title ) {
+		return ( $title && $title->canExist() && $title->getArticleID() > 0
+			&& $title->isKnown() );
+	}
+
+	/**
+	 * @see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/PageProperties/+/548d30609c512a79e202dfa7c02a298c66ca34fa/includes/PageProperties.php
+	 * @param Title $title
+	 * @param OutputPage $outputPage
+	 * @return void
+	 */
+	public static function setJsonLD( $title, $outputPage ) {
+		if ( !class_exists( '\EasyRdf\Graph' ) || !class_exists( '\ML\JsonLD\JsonLD' ) ) {
+			return;
+		}
+
+		// @TODO use directly the function makeExportDataForSubject
+		// SemanticMediawiki/includes/export/SMW_Exporter.php
+		$export_rdf = SpecialPage::getTitleFor( 'ExportRDF' );
+		if ( $export_rdf->isKnown() ) {
+			$export_url = $export_rdf->getFullURL( [
+				'page' => $title->getFullText(),
+				'recursive' => '1',
+				'backlinks' => 0
+			] );
+
+			try {
+				$foaf = new \EasyRdf\Graph( $export_url );
+				$foaf->load();
+
+				$format = \EasyRdf\Format::getFormat( 'jsonld' );
+				$output = $foaf->serialise( $format, [
+					'compact' => true,
+				] );
+
+			} catch ( Exception $e ) {
+				self::$Logger->error( 'EasyRdf error: ' . $export_url );
+				return;
+			}
+
+			// https://hotexamples.com/examples/-/EasyRdf_Graph/serialise/php-easyrdf_graph-serialise-method-examples.html
+			if ( is_scalar( $output ) ) {
+				$outputPage->addHeadItem( 'json-ld', Html::Element(
+						'script', [ 'type' => 'application/ld+json' ], $output
+					)
+				);
+			}
+		}
+	}
+}

--- a/src/JsonLDSerializer.php
+++ b/src/JsonLDSerializer.php
@@ -7,10 +7,10 @@
 
 namespace SMT;
 
-use Title;
+use Html;
 use OutputPage;
 use SpecialPage;
-use Html;
+use Title;
 
 class JsonLDSerializer {
 	/**


### PR DESCRIPTION
rebased version of https://github.com/SemanticMediaWiki/SemanticMetaTags/pull/80
(adds json-ld serialization using https://github.com/easyrdf/easyrdf from SMW's standard RDF serialization)

see also https://github.com/easyrdf/easyrdf/pull/408

