### PR TITLE
README.md: requirements info (PHP 7.1 vs. 7.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ with content generated from selected properties to create:
 
 ## Requirements
 
-- PHP 7.1 or later
+- PHP 7.4 or later
 - MediaWiki 1.31 or later
 - [Semantic MediaWiki][smw] 3.1 or later
 


### PR DESCRIPTION
README.md used another minimum PHP version (7.1) than composer.json does (7.4). I assume composer.json's version is the correct one.
