### PR TITLE
Suppress the warnings about dynamic property until EasyRDF is fixed

### DIFF
--- a/src/JsonLDSerializer.php
+++ b/src/JsonLDSerializer.php
@@ -56,7 +56,7 @@ class JsonLDSerializer {
 
 			try {
 				$foaf = new \EasyRdf\Graph( $export_url );
-				$foaf->load();
+				@$foaf->load();
 
 				$format = \EasyRdf\Format::getFormat( 'jsonld' );
 				$output = $foaf->serialise( $format, [

--- a/src/JsonLDSerializer.php
+++ b/src/JsonLDSerializer.php
@@ -52,7 +52,7 @@ class JsonLDSerializer {
 				'page' => $title->getFullText(),
 				'recursive' => '1',
 				'backlinks' => 0
-			] );
+			], false, PROTO_FALLBACK );
 
 			try {
 				$foaf = new \EasyRdf\Graph( $export_url );


### PR DESCRIPTION
Suppress the warnings about dynamic property
until EasyRDF is fixed.

Fixes #92