### PR TITLE
Add CI for MW 1.44-1.45 and remove MW 1.39

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,19 +17,33 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.39'
-            smw_version: 5.1.0
+          - mediawiki_version: '1.43'
+            smw_version: 6.0.1
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:10"
+            coverage: true
+            experimental: false
+          - mediawiki_version: '1.43'
+            smw_version: 6.0.1
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:10"
             coverage: false
             experimental: false
-          - mediawiki_version: '1.43'
-            smw_version: 6.0.1
+          - mediawiki_version: '1.44'
+            smw_version: dev-master
+            php_version: 8.2
+            database_type: mysql
+            database_image: "mariadb:11.8"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.44'
+            smw_version: dev-master
             php_version: 8.3
             database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: true
+            database_image: "mariadb:11.8"
+            coverage: false
             experimental: false
 
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
             database_image: "mariadb:11.8"
             coverage: false
             experimental: false
-          - mediawiki_version: '1.44'
+          - mediawiki_version: '1.45'
             smw_version: dev-master
             php_version: 8.3
             database_type: mysql

--- a/extension.json
+++ b/extension.json
@@ -31,8 +31,7 @@
 		"SMT\\": "src/"
 	},
 	"TestAutoloadNamespaces": {
-		"SMT\\Tests\\": "tests/phpunit/Unit/",
-		"SMT\\Tests\\Integration\\": "tests/phpunit/Integration/"
+		"SMT\\Tests\\": "tests/phpunit/"
 	},
 	"load_composer_autoloader": true,
 	"manifest_version": 2

--- a/extension.json
+++ b/extension.json
@@ -10,9 +10,9 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.39",
+		"MediaWiki": ">= 1.43",
 		"extensions": {
-			"SemanticMediaWiki": ">= 5.0.0"
+			"SemanticMediaWiki": ">= 6.0.0"
 		}
 	},
 	"MessagesDirs": {

--- a/src/JsonLDSerializer.php
+++ b/src/JsonLDSerializer.php
@@ -7,10 +7,11 @@
 
 namespace SMT;
 
-use Html;
-use OutputPage;
-use SpecialPage;
-use Title;
+use Exception;
+use MediaWiki\Html\Html;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\Title\Title;
 
 class JsonLDSerializer {
 	/**

--- a/src/OutputPageHtmlTagsInserter.php
+++ b/src/OutputPageHtmlTagsInserter.php
@@ -2,6 +2,7 @@
 
 namespace SMT;
 
+use MediaWiki\Html\Html;
 use OutputPage;
 
 /**
@@ -115,7 +116,7 @@ class OutputPageHtmlTagsInserter {
 			$this->metaPropertyMarkup = true;
 		}
 
-		$content = $comment . \Html::element( 'meta', [
+		$content = $comment . Html::element( 'meta', [
 			'property' => $tag,
 			'content'  => $content
 		] );

--- a/src/OutputPageHtmlTagsInserter.php
+++ b/src/OutputPageHtmlTagsInserter.php
@@ -3,7 +3,7 @@
 namespace SMT;
 
 use MediaWiki\Html\Html;
-use OutputPage;
+use MediaWiki\Output\OutputPage;
 
 /**
  * @license GPL-2.0-or-later

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -2,9 +2,9 @@
 
 namespace SMT\Tests;
 
+use MediaWiki\Title\Title;
 use SMT\HookRegistry;
 use SMT\Options;
-use Title;
 
 /**
  * @covers \SMT\HookRegistry

--- a/tests/phpunit/Unit/OutputPageHtmlTagsInserterTest.php
+++ b/tests/phpunit/Unit/OutputPageHtmlTagsInserterTest.php
@@ -2,6 +2,7 @@
 
 namespace SMT\Tests;
 
+use MediaWiki\Title\Title;
 use SMT\OutputPageHtmlTagsInserter;
 
 /**
@@ -27,7 +28,7 @@ class OutputPageHtmlTagsInserterTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testTryToUseOutputPageForSpecialPage() {
-		$title = $this->getMockBuilder( '\Title' )
+		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -54,7 +55,7 @@ class OutputPageHtmlTagsInserterTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testTryToUseOutputPageForNonViewAction() {
-		$title = $this->getMockBuilder( '\Title' )
+		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/OutputPageHtmlTagsInserterTest.php
+++ b/tests/phpunit/Unit/OutputPageHtmlTagsInserterTest.php
@@ -2,6 +2,7 @@
 
 namespace SMT\Tests;
 
+use MediaWiki\Output\OutputPage;
 use MediaWiki\Title\Title;
 use SMT\OutputPageHtmlTagsInserter;
 
@@ -17,7 +18,7 @@ use SMT\OutputPageHtmlTagsInserter;
 class OutputPageHtmlTagsInserterTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCanConstruct() {
-		$outputPage = $this->getMockBuilder( '\OutputPage' )
+		$outputPage = $this->getMockBuilder( OutputPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -36,7 +37,7 @@ class OutputPageHtmlTagsInserterTest extends \PHPUnit\Framework\TestCase {
 			->method( 'isSpecialPage' )
 			->willReturn( true );
 
-		$outputPage = $this->getMockBuilder( '\OutputPage' )
+		$outputPage = $this->getMockBuilder( OutputPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -63,7 +64,7 @@ class OutputPageHtmlTagsInserterTest extends \PHPUnit\Framework\TestCase {
 			->method( 'isSpecialPage' )
 			->willReturn( false );
 
-		$outputPage = $this->getMockBuilder( '\OutputPage' )
+		$outputPage = $this->getMockBuilder( OutputPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -83,7 +84,7 @@ class OutputPageHtmlTagsInserterTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testTryToAddContentForBlacklistedTag() {
-		$outputPage = $this->getMockBuilder( '\OutputPage' )
+		$outputPage = $this->getMockBuilder( OutputPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -100,7 +101,7 @@ class OutputPageHtmlTagsInserterTest extends \PHPUnit\Framework\TestCase {
 	 * @dataProvider nonOgTagProvider
 	 */
 	public function testAddTagForNonOgContent( $tag, $content, $expected ) {
-		$outputPage = $this->getMockBuilder( '\OutputPage' )
+		$outputPage = $this->getMockBuilder( OutputPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -118,7 +119,7 @@ class OutputPageHtmlTagsInserterTest extends \PHPUnit\Framework\TestCase {
 	 * @dataProvider propertyTagProvider
 	 */
 	public function testAddTagOnMetaPropertyPrefixContent( $prefixes, $tag, $content, $expected ) {
-		$outputPage = $this->getMockBuilder( '\OutputPage' )
+		$outputPage = $this->getMockBuilder( OutputPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
* Adds support for MW 1.44 and 1.45.
* Bumps minimum MediaWiki version to 1.43.
* Bumps minimum SMW version to 6.0.