### PR TITLE
Use strict semantic versioning for the version number

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 This file contains the RELEASE-NOTES of the **Semantic Meta Tags** (a.k.a. SMT) extension.
 
-### 7.0.0-alpha
+### 5.0.0-alpha
 
 * Added support for Semantic MediaWiki 7.0
 * Raised the minimum requirement for
@@ -8,7 +8,6 @@ This file contains the RELEASE-NOTES of the **Semantic Meta Tags** (a.k.a. SMT) 
   * MediaWiki to version 1.43 and later
 * Updated to Semantic MediaWiki 7.0's namespaced data-item classes
 * Moved the extension registration and settings defaults into `extension.json` (the `$smtg…` configuration variable names are unchanged)
-* The major version jumps from 4.x to 7.0 to track the Semantic MediaWiki release it supports
 
 ### 4.1.1
 

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.x-dev"
+			"dev-master": "5.x-dev"
 		}
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticMetaTags",
-	"version": "7.0.0-alpha",
+	"version": "5.0.0-alpha",
 	"author": [
 		"James Hong Kong"
 	],


### PR DESCRIPTION
## Summary

Adopt semantic versioning for the **SemanticMetaTags** version number. Versioning the extension independently of Semantic MediaWiki lets it introduce its own breaking changes mid-cycle — between Semantic MediaWiki major releases — instead of holding them to realign its major with the next Semantic MediaWiki major.

This sets the version to the extension's own next major, `5.0.0-alpha` (branch-alias `5.x-dev`), rather than tracking the Semantic MediaWiki major. The `SemanticMediaWiki >= 7.0` requirement (the Semantic MediaWiki version this release targets) is unchanged.

## Changes

- `extension.json`: version → `5.0.0-alpha`
- `composer.json`: `extra.branch-alias.dev-master` → `5.x-dev`
- `RELEASE-NOTES.md`: heading → `5.0.0-alpha`, and drop the note that described the version tracking / mirroring the Semantic MediaWiki major
- `@since 7.0.0` docblocks updated to `@since 5.0.0` where present
